### PR TITLE
Disable autocomplete.

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -38,7 +38,7 @@
   <table>
     <tr>
       <td>Role</td>
-      <td><input name='role' list='roles' style="width: 500px;">
+      <td><input name='role' list='roles' style="width: 500px;" autocomplete="off">
       <datalist id='roles'>
       <% roles.each do |role|
         %><option value='<%= role %>'><%= role.gsub(/.*:role\//, '' ) %></option>


### PR DESCRIPTION
The autocomplete doubles up the list of roles, causing confusion between dev and prod.