### PR TITLE
Add in python-dev ubuntu dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.1
 RUN apt-get update
-RUN apt-get install -y  python-pip
+RUN apt-get install -y  python-pip python-dev
 RUN pip install --upgrade awscli
 ADD ./Gemfile /code/Gemfile
 ADD ./Gemfile.lock /code/Gemfile.lock


### PR DESCRIPTION
Fixes an issues where Docker fails due to missing python header files.