### PR TITLE
saving miniscule amounts of disk space, container naming convenience.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ruby:2.1
-RUN apt-get update
-RUN apt-get install -y  python-pip python-dev
-RUN pip install --upgrade awscli
+RUN apt-get update && apt-get install -y \
+    python-pip \
+    python-dev && \
+    pip install --upgrade awscli && \
+    rm -rf /var/lib/apt/lists/*
 ADD ./Gemfile /code/Gemfile
 ADD ./Gemfile.lock /code/Gemfile.lock
 WORKDIR /code

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
+NAME = ec2metadata
 
 up: 
-	docker run -e RACK_ENV=production -it --rm -p 127.0.0.1:8009:4567 -v `ls -d ~/.aws`:/root/.aws farrellit/ec2metadata:latest
+	docker run --name $(NAME) \
+		-e RACK_ENV=production \
+		-it --rm -p 127.0.0.1:8009:4567 \
+		-v `ls -d ~/.aws`:/root/.aws farrellit/ec2metadata:latest
 
 daemon: 
-	docker run -e RACK_ENV=production --rm -d -p 127.0.0.1:8009:4567 -v `ls -d ~/.aws`:/root/.aws farrellit/ec2metadata:latest
+	docker run --name $(NAME) \
+		-e RACK_ENV=production \
+		--rm -d -p 127.0.0.1:8009:4567 \
+		-v `ls -d ~/.aws`:/root/.aws farrellit/ec2metadata:latest
 
 pull:
 	docker pull farrellit/ec2metadata:latest


### PR DESCRIPTION
On a previous commit of this repo, I was able to save 400mb of disk space by using ruby:2.2-slim.  That doesn't work with the latest code, so the only change to the dockerfile is to remove unneeded apt data, and combine some steps.