### PR TITLE
Add support for Windows via WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea
+*.iml
 roles.json

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ This simply runs `setup.sh` in recent versions.
 make daemon
 ```
 
+### Windows Subsystem for Linux (WSL)
+If you're using [Docker for Windows](https://docs.docker.com/docker-for-windows/install/), and executing it via the WSL Bash shell,
+the only additional thing needed to make this work is to define a `AWS_PROFILE_PATH` environment variable to a location on Windows
+where the `.aws` directory is located. Since Docker is running on the Windows host, it is going to expect a path to somewhere in Windows,
+and not the Ubuntu instance where the shell is running. 
+
+For example: `export AWS_PROFILE_PATH="/c/Users/<username>/.aws"`
+
+_You may also need to symlink `/mnt/c` to `/c` so the WSL and Windows paths are in sync: `ln -s /mnt/c /c`_
+
+If you are executing Docker from Windows natively without WSL, a variation of `setup.sh` will be needed as that is currently assuming
+a unix environment.
+
+
 ## Usage
 
 Navigate to <http://169.254.169.254>.

--- a/setup.sh
+++ b/setup.sh
@@ -19,10 +19,14 @@ else
   echo "IP Configuration utility not detected correctly"
   exit 1
 fi
-# this docker runs on 80 and will have to be sudoed
-# better than a redirect, I believe.
 
-$sudo docker run --name ec2metadata -e RACK_ENV=production \
+if which "docker.exe" > /dev/null 2>&1; then
+  dockercmd="docker.exe"
+else
+  dockercmd="docker"
+fi
+
+$sudo $dockercmd run --name ec2metadata -e RACK_ENV=production \
   ${args:---rm -d} -p $LOCALIP:80:4567 \
   -v `ls -d ~/.aws`:/root/.aws \
   -e MYNAME \

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,6 @@ fi
 
 $sudo $dockercmd run --name ec2metadata -e RACK_ENV=production \
   ${args:---rm -d} -p $LOCALIP:80:4567 \
-  -v `ls -d ~/.aws`:/root/.aws \
+  -v `ls -d ${AWS_PROFILE_PATH:-~/.aws}`:/root/.aws \
   -e MYNAME \
   ${image:-farrellit/ec2metadata:latest}

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ fi
 # better than a redirect, I believe.
 
 $sudo docker run --name ec2metadata -e RACK_ENV=production \
-  ${args:---rm -d} -p 169.254.169.254:80:4567 \
+  ${args:---rm -d} -p $LOCALIP:80:4567 \
   -v `ls -d ~/.aws`:/root/.aws \
   -e MYNAME \
   ${image:-farrellit/ec2metadata:latest}


### PR DESCRIPTION
Backwards-compatibly support Windows via Windows Subsystem for Linux (WSL).

- Look for Windows docker executable
- Add `AWS_PROFILE_PATH` environment variable override for `~/.aws` profile path

Replaces: https://github.com/farrellit/ec2metadata-role-assumption/pull/27