### PR TITLE
Use docker network instead of loopback ; use port 80 instead of 4567 (#30)

### DIFF
--- a/ec2metadata.rb
+++ b/ec2metadata.rb
@@ -168,7 +168,7 @@ require 'shellwords'
 require 'open3'
 
 set :bind, '0.0.0.0'
-set :port, 4567
+set :port, 80
 
 
 class PerRequesterRoles 


### PR DESCRIPTION
Do not use the lo interface in Linux.  Any IPs assigned outside of the 127.0.0.0/8 network will be shared across all interfaces.  This means your 169.254.169.254 IP and role assumption will be shared across the network!

Instead use a docker network (bridge) on the 169.254.169.252/30 network just for ec2metadata which should be OS-agnostic.

Run the metadata service on port 80.  Doing port translation from port 80 to 4567 was not playing well using the docker bridge.  Since the service is already running as root there is no benefit to running on port 4567 anyway.

Also - remember to remove 169.254.169.254 from localhost or this will not work!