### PR TITLE
Add instance-id endpoint to support terraform

### DIFF
--- a/ec2metadata.rb
+++ b/ec2metadata.rb
@@ -209,6 +209,13 @@ get %r|/latest/meta-data/iam/security-credentials/?| do
   end
 end
 
+# This is here to support hashicorp/terraform
+get %r|/latest/meta-data/instance-id/?| do
+  status 200
+  content_type 'text/plain'
+  "i-123456"
+end
+
 #require 'digest/sha1' # crc should be faster!
 require 'zlib' 
 require 'date'


### PR DESCRIPTION
This small path is needed to support terraform with the s3 backend.

See relevant upstream code here
https://github.com/terraform-providers/terraform-provider-aws/blob/ee18327b50777d6f5e3bc06277cd723c5953ef2d/aws/auth_helpers.go#L206-L215